### PR TITLE
Use BMI version in module name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(bmi-example-fortran Fortran)
 
 set(model_name heatf)
 set(bmi_name bmi${model_name})
+set(bmi_major_version 1)
+set(bmi_minor_version 2)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 set(CMAKE_MACOSX_RPATH 1)
@@ -12,7 +14,7 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 # Locate the installed Fortran BMI bindings (bmif library and module file)
 # through CMAKE_PREFIX_PATH.
 find_library(bmif_lib bmif)
-find_path(bmif_inc bmif.mod)
+find_path(bmif_inc bmif_${bmi_major_version}_${bmi_minor_version}.mod)
 include_directories(${bmif_inc})
 
 add_subdirectory(heat)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,23 @@ project(bmi-example-fortran Fortran)
 
 set(model_name heatf)
 set(bmi_name bmi${model_name})
-set(bmi_major_version 1)
-set(bmi_minor_version 2)
+
+# Determine the Fortran BMI version.
+if(DEFINED ENV{BMIF_VERSION})
+  set(bmif_version $ENV{BMIF_VERSION})
+else()
+  set(bmif_version "1.2")
+endif()
+string(REPLACE "." "_" bmif_module_version ${bmif_version})
+message("-- BMIF version - ${bmif_version}")
+message("-- BMIF module version - ${bmif_module_version}")
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
 # Locate the installed Fortran BMI bindings (bmif library and module file)
 # through CMAKE_PREFIX_PATH.
 find_library(bmif_lib bmif)
-find_path(bmif_inc bmif_${bmi_major_version}_${bmi_minor_version}.mod)
+find_path(bmif_inc bmif_${bmif_module_version}.mod)
 include_directories(${bmif_inc})
 
 add_subdirectory(heat)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(bmi-example-fortran Fortran)
 
@@ -8,8 +8,6 @@ set(bmi_major_version 1)
 set(bmi_minor_version 2)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
-set(CMAKE_MACOSX_RPATH 1)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 # Locate the installed Fortran BMI bindings (bmif library and module file)
 # through CMAKE_PREFIX_PATH.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ This repository is organized with the following directories:
 
 ## Build/Install
 
-To build this example from source with cmake, run
+To build this example from source with cmake,
+using the current Fortran BMI version, run
 
+    export BMIF_VERSION=1.2
     mkdir _build && cd _build
     cmake .. -DCMAKE_INSTALL_PREFIX=<path-to-installation>
     make

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Then, to install (on both Linux and macOS):
 
     make install
 
-The installation will look like:
+The installation will look like
+(on macOS, using v1.2 of the Fortran BMI specification):
 
 ```bash
 .
@@ -70,15 +71,16 @@ The installation will look like:
 |   |-- run_bmiheatf
 |   `-- run_heatf
 |-- include
-|   |-- bmif.mod
+|   |-- bmif_1_2.mod
 |   |-- bmiheatf.mod
 |   `-- heatf.mod
 `-- lib
-    |-- libbmif.dylib
+    |-- libbmif.1.2.dylib
+    |-- libbmif.dylib -> libbmif.1.2.dylib
     |-- libbmiheatf.dylib
     `-- libheatf.dylib
 
-3 directories, 8 files
+3 directories, 9 files
 ```
 
 Run unit tests and examples of using the sample implementation with

--- a/bmi_heat/bmi_heat.f90
+++ b/bmi_heat/bmi_heat.f90
@@ -1,7 +1,7 @@
 module bmiheatf
 
   use heatf
-  use bmif
+  use bmif_1_2
   use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_f_pointer
   implicit none
 

--- a/examples/conflicting_instances_ex.f90
+++ b/examples/conflicting_instances_ex.f90
@@ -1,7 +1,7 @@
 ! Do two instances of bmi_heat conflict?
 program conflicting_instances_ex
 
-  use bmif, only: BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use bmiheatf
   use testing_helpers
   implicit none

--- a/examples/get_value_ex.f90
+++ b/examples/get_value_ex.f90
@@ -1,7 +1,7 @@
 ! Test the get_value, get_value_ptr, and get_value_at_indices functions.
 program get_value_ex
 
-  use bmif, only: BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use bmiheatf
   use testing_helpers
   implicit none

--- a/examples/info_ex.f90
+++ b/examples/info_ex.f90
@@ -1,7 +1,7 @@
 ! Test the basic info BMI methods.
 program info_test
 
-  use bmif
+  use bmif_1_2
   use bmiheatf
   implicit none
 

--- a/examples/irf_ex.f90
+++ b/examples/irf_ex.f90
@@ -1,7 +1,7 @@
 ! Test the lifecycle and time BMI methods.
 program irf_test
 
-  use bmif, only: BMI_MAX_UNITS_NAME
+  use bmif_1_2, only: BMI_MAX_UNITS_NAME
   use bmiheatf
   implicit none
 

--- a/examples/set_value_ex.f90
+++ b/examples/set_value_ex.f90
@@ -1,7 +1,7 @@
 ! Test the set_value and set_value_at_indices functions.
 program set_value_ex
 
-  use bmif, only: BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use bmiheatf
   use testing_helpers
   implicit none

--- a/examples/vargrid_ex.f90
+++ b/examples/vargrid_ex.f90
@@ -1,7 +1,7 @@
 ! Test the BMI get_var_* and get_grid_* functions.
 program vargrid_test
 
-  use bmif, only: BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use bmiheatf
   implicit none
 

--- a/scripts/update_rpaths.sh
+++ b/scripts/update_rpaths.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # Updates runtime paths for executables on macOS.
 
+bmif_version=${BMIF_VERSION:-1.2}
+
 run_install_name_tool() {
     install_name_tool \
-	-change @rpath/libbmif.dylib \
-	    ${CONDA_PREFIX}/lib/libbmif.dylib \
+	-change @rpath/libbmif.$bmif_version.dylib \
+	    ${CONDA_PREFIX}/lib/libbmif.$bmif_version.dylib \
 	-change @rpath/libgfortran.3.dylib \
 	    ${CONDA_PREFIX}/lib/libgfortran.3.dylib \
 	-change @rpath/libquadmath.0.dylib \

--- a/tests/test_by_reference.f90
+++ b/tests/test_by_reference.f90
@@ -1,6 +1,6 @@
 program test_by_reference
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/tests/test_finalize.f90
+++ b/tests/test_finalize.f90
@@ -1,6 +1,6 @@
 program test_finalize
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, config_file
 

--- a/tests/test_get_component_name.f90
+++ b/tests/test_get_component_name.f90
@@ -1,6 +1,6 @@
 program test_get_component_name
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_COMPONENT_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_COMPONENT_NAME
   use bmiheatf
   use fixtures, only: status
 

--- a/tests/test_get_current_time.f90
+++ b/tests/test_get_current_time.f90
@@ -1,6 +1,6 @@
 program test_get_current_time
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_end_time.f90
+++ b/tests/test_get_end_time.f90
@@ -1,6 +1,6 @@
 program test_get_end_time
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_connectivity.f90
+++ b/tests/test_get_grid_connectivity.f90
@@ -1,6 +1,6 @@
 program test_get_grid_connectivity
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_offset.f90
+++ b/tests/test_get_grid_offset.f90
@@ -1,6 +1,6 @@
 program test_get_grid_offset
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_origin.f90
+++ b/tests/test_get_grid_origin.f90
@@ -1,6 +1,6 @@
 program test_get_grid_origin
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_rank.f90
+++ b/tests/test_get_grid_rank.f90
@@ -1,6 +1,6 @@
 program test_get_grid_rank
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_shape.f90
+++ b/tests/test_get_grid_shape.f90
@@ -1,6 +1,6 @@
 program test_get_grid_shape
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_size.f90
+++ b/tests/test_get_grid_size.f90
@@ -1,6 +1,6 @@
 program test_get_grid_size
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_spacing.f90
+++ b/tests/test_get_grid_spacing.f90
@@ -1,6 +1,6 @@
 program test_get_grid_spacing
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_type.f90
+++ b/tests/test_get_grid_type.f90
@@ -1,6 +1,6 @@
 program test_get_grid_type
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_x.f90
+++ b/tests/test_get_grid_x.f90
@@ -1,6 +1,6 @@
 program test_get_grid_x
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_y.f90
+++ b/tests/test_get_grid_y.f90
@@ -1,6 +1,6 @@
 program test_get_grid_y
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_grid_z.f90
+++ b/tests/test_get_grid_z.f90
@@ -1,6 +1,6 @@
 program test_get_grid_z
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_input_var_names.f90
+++ b/tests/test_get_input_var_names.f90
@@ -1,6 +1,6 @@
 program test_get_input_var_names
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_VAR_NAME
   use bmiheatf
   use fixtures, only: status
 

--- a/tests/test_get_output_var_names.f90
+++ b/tests/test_get_output_var_names.f90
@@ -1,6 +1,6 @@
 program test_get_output_var_names
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_VAR_NAME
   use bmiheatf
   use fixtures, only: status
 

--- a/tests/test_get_start_time.f90
+++ b/tests/test_get_start_time.f90
@@ -1,6 +1,6 @@
 program test_get_start_time
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_time_step.f90
+++ b/tests/test_get_time_step.f90
@@ -1,6 +1,6 @@
 program test_get_time_step
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_time_units.f90
+++ b/tests/test_get_time_units.f90
@@ -1,6 +1,6 @@
 program test_get_time_units
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_value.f90
+++ b/tests/test_get_value.f90
@@ -1,6 +1,6 @@
 program test_get_value
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/tests/test_get_value_at_indices.f90
+++ b/tests/test_get_value_at_indices.f90
@@ -1,6 +1,6 @@
 program test_get_value_at_indices
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/tests/test_get_value_ptr.f90
+++ b/tests/test_get_value_ptr.f90
@@ -1,6 +1,6 @@
 program test_get_value_ptr
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/tests/test_get_var_grid.f90
+++ b/tests/test_get_var_grid.f90
@@ -1,6 +1,6 @@
 program test_get_var_grid
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_var_itemsize.f90
+++ b/tests/test_get_var_itemsize.f90
@@ -1,6 +1,6 @@
 program test_get_var_itemsize
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_var_nbytes.f90
+++ b/tests/test_get_var_nbytes.f90
@@ -1,6 +1,6 @@
 program test_get_var_nbytes
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_var_type.f90
+++ b/tests/test_get_var_type.f90
@@ -1,6 +1,6 @@
 program test_get_var_type
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_get_var_units.f90
+++ b/tests/test_get_var_units.f90
@@ -1,6 +1,6 @@
 program test_get_var_units
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_initialize.f90
+++ b/tests/test_initialize.f90
@@ -1,6 +1,6 @@
 program test_initialize
 
-  use bmif, only: BMI_SUCCESS
+  use bmif_1_2, only: BMI_SUCCESS
   use bmiheatf
   use fixtures, only: status
 

--- a/tests/test_set_value.f90
+++ b/tests/test_set_value.f90
@@ -1,6 +1,6 @@
 program test_set_value
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/tests/test_set_value_at_indices.f90
+++ b/tests/test_set_value_at_indices.f90
@@ -1,6 +1,6 @@
 program test_set_value_at_indices
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/tests/test_update.f90
+++ b/tests/test_update.f90
@@ -1,6 +1,6 @@
 program test_update
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_update_frac.f90
+++ b/tests/test_update_frac.f90
@@ -1,6 +1,6 @@
 program test_update_frac
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 

--- a/tests/test_update_until.f90
+++ b/tests/test_update_until.f90
@@ -1,6 +1,6 @@
 program test_update_until
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 


### PR DESCRIPTION
This PR updates the example to use the new method of naming the module that defines the Fortran BMI, described in https://github.com/csdms/bmi-fortran/pull/36. Now, instead of

    use bmif

we instead

    use bmif_1_2

for v1.2 of the Fortran BMI. Further, the module file is named `bmif_1_2.mod` instead of `bmif.mod`. The build instructions have been updated to reflect this. All examples and tests have also been updated.