### PR TITLE
Build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+# bmi-example-fortran
+
 cmake_minimum_required(VERSION 3.0)
 
 project(bmi-example-fortran Fortran)
@@ -22,6 +24,8 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 find_library(bmif_lib bmif)
 find_path(bmif_inc bmif_${bmif_module_version}.mod)
 include_directories(${bmif_inc})
+message("-- bmif_lib - ${bmif_lib}")
+message("-- bmif_inc - ${bmif_inc}")
 
 add_subdirectory(heat)
 add_subdirectory(bmi_heat)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Basic Model Interface](https://img.shields.io/badge/CSDMS-Basic%20Model%20Interface-green.svg)](https://bmi.readthedocs.io/)
 [![Build Status](https://travis-ci.org/csdms/bmi-example-fortran.svg?branch=master)](https://travis-ci.org/csdms/bmi-example-fortran)
 
 # bmi-example-fortran
@@ -18,13 +19,14 @@ Tests and examples of using the BMI are provided.
 The model is written in Fortran 90.
 The BMI is written in Fortran 2003.
 
-**Prerequisite:**
-The Fortran BMI bindings must be installed before building this example.
-Follow the install directions given in the
-[README](https://github.com/csdms/bmi-fortran/blob/master/README.md)
-in that repository.
-You can choose to build them from source
-or install them through a conda binary.
+**Prerequisites:**
+* A Fortran compiler
+* CMake
+* The Fortran BMI bindings. Follow the build and install directions
+  given in the
+  [README](https://github.com/csdms/bmi-fortran/blob/master/README.md)
+  in that repository.  You can choose to build them from source or
+  install them through a conda binary (Linux and macOS only).
 
 This repository is organized with the following directories:
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ Tests and examples of using the BMI are provided.
 The model is written in Fortran 90.
 The BMI is written in Fortran 2003.
 
-**Prerequisites:**
-* A Fortran compiler
-* CMake
-* The Fortran BMI bindings. Follow the build and install directions
-  given in the
-  [README](https://github.com/csdms/bmi-fortran/blob/master/README.md)
-  in that repository.  You can choose to build them from source or
-  install them through a conda binary (Linux and macOS only).
-
 This repository is organized with the following directories:
 
 <dl>
@@ -47,6 +38,15 @@ This repository is organized with the following directories:
 ## Build/Install
 
 This example can be built on Linux, macOS, and Windows.
+
+**Prerequisites:**
+* A Fortran compiler
+* CMake
+* The Fortran BMI bindings. Follow the build and install directions
+  given in the
+  [README](https://github.com/csdms/bmi-fortran/blob/master/README.md)
+  in that repository.  You can choose to build them from source or
+  install them through a conda binary (Linux and macOS only).
 
 ### Linux and macOS
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ This repository is organized with the following directories:
 
 ## Build/Install
 
+This example can be built on Linux, macOS, and Windows.
+
+### Linux and macOS
+
 To build this example from source with cmake,
 using the current Fortran BMI version, run
 
@@ -84,6 +88,30 @@ The installation will look like
 
 3 directories, 9 files
 ```
+
+Run unit tests and examples of using the sample implementation with
+
+    ctest
+
+### Windows
+
+To configure this example from source with cmake,
+using the current Fortran BMI version, run
+
+    set "BMIF_VERSION=1.2"
+    mkdir _build && cd _build
+    cmake .. ^
+	  -G "NMake Makefiles" ^
+	  -DCMAKE_INSTALL_PREFIX=<path-to-installation> ^
+	  -DCMAKE_BUILD_TYPE=Release
+
+where `<path-to-installation>` is the base directory
+in which the Fortran BMI bindings have been installed
+(`C:\Program Files (x86)` is the default).
+
+Then, to build and install:
+
+	cmake --build . --target install --config Release
 
 Run unit tests and examples of using the sample implementation with
 

--- a/bmi_heat/CMakeLists.txt
+++ b/bmi_heat/CMakeLists.txt
@@ -1,15 +1,27 @@
-add_library(${bmi_name} SHARED bmi_heat.f90)
+# bmi-heat
+
+# Create shared library, except on Windows.
+if(WIN32)
+  add_library(${bmi_name} bmi_heat.f90)
+else()
+  add_library(${bmi_name} SHARED bmi_heat.f90)
+endif()
 target_link_libraries(${bmi_name} ${model_name} ${bmif_lib})
 
 add_executable(run_${bmi_name} bmi_main.f90)
 target_link_libraries(run_${bmi_name} ${bmi_name})
 
 install(
-  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_${bmi_name}
-  DESTINATION bin)
+  TARGETS run_${bmi_name}
+  RUNTIME DESTINATION bin
+)
 install(
   TARGETS ${bmi_name}
-  DESTINATION lib)
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
 install(
   FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmi_name}.mod
-  DESTINATION include)
+  DESTINATION include
+)

--- a/bmi_heat/bmi_main.f90
+++ b/bmi_heat/bmi_main.f90
@@ -26,7 +26,7 @@ program bmi_main
      write(*,"(a)")
      write(*,"(a)") "Run the heatf model through its BMI with a configuration file."
      write(*,"(a)") "Output is written to the file `bmiheatf.out`."
-     return
+     stop
   end if
 
   open(file_unit,file=output_file)

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -1,14 +1,26 @@
-add_library(${model_name} SHARED heat.f90)
+# heat
+
+# Create shared library, except on Windows.
+if(WIN32)
+  add_library(${model_name} heat.f90)
+else()
+  add_library(${model_name} SHARED heat.f90)
+endif()
 
 add_executable(run_${model_name} main.f90)
 target_link_libraries(run_${model_name} ${model_name})
 
 install(
   TARGETS run_${model_name}
-  DESTINATION bin)
+  RUNTIME DESTINATION bin
+)
 install(
   TARGETS ${model_name}
-  DESTINATION lib)
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
 install(
   FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${model_name}.mod
-  DESTINATION include)
+  DESTINATION include
+)

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(run_${model_name} main.f90)
 target_link_libraries(run_${model_name} ${model_name})
 
 install(
-  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_${model_name}
+  TARGETS run_${model_name}
   DESTINATION bin)
 install(
   TARGETS ${model_name}


### PR DESCRIPTION
This PR allows the example to be built on Windows. It's somewhat of a half-measure, though, because only static libraries are built and linked on Windows. (See #5.) The build/install process is unchanged on Linux and macOS, although the cmake build process was improved.

The Windows build has been tested with Intel Fortran and the flang compiler available through conda.