### PR TITLE
Run memcheck with CI

### DIFF
--- a/.github/workflows/conda-and-cmake.yml
+++ b/.github/workflows/conda-and-cmake.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         working-directory: ${{ github.workspace }}/examples
         run: |
-          conda install -c conda-forge valgrind
+          sudo apt-get install -y valgrind
           valgrind \
             --tool=memcheck \
             --leak-check=yes \

--- a/.github/workflows/conda-and-cmake.yml
+++ b/.github/workflows/conda-and-cmake.yml
@@ -43,8 +43,21 @@ jobs:
 
       - name: Build
         working-directory: ${{ github.workspace }}/build
-        run: cmake --build . --config ${{ matrix.build-type }}
+        run: cmake --build . --target install --config ${{ matrix.build-type }}
 
       - name: Test
         working-directory: ${{ github.workspace }}/build
         run: ctest -C ${{ matrix.build-type }} --output-on-failure
+
+      - name: Memcheck
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: ${{ github.workspace }}/examples
+        run: |
+          conda install -c conda-forge valgrind
+          valgrind \
+            --tool=memcheck \
+            --leak-check=yes \
+            --show-reachable=yes \
+            --num-callers=20 \
+            --track-fds=yes \
+            run_bmiheatf test1.cfg

--- a/.github/workflows/conda-and-cmake.yml
+++ b/.github/workflows/conda-and-cmake.yml
@@ -39,7 +39,10 @@ jobs:
 
       - name: Configure cmake
         working-directory: ${{ github.workspace }}/build
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+        run: |
+          cmake $GITHUB_WORKSPACE \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+            -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
 
       - name: Build
         working-directory: ${{ github.workspace }}/build


### PR DESCRIPTION
This PR adds a task to the GitHub Actions build/test job to run valgrind `memtest`.

Initially, I tried installing valgrind through conda, but it errored when run. The apt package works.

This fixes #13.