### PR TITLE
Standardize model

### DIFF
--- a/.github/workflows/conda-and-cmake.yml
+++ b/.github/workflows/conda-and-cmake.yml
@@ -31,11 +31,13 @@ jobs:
           channel-priority: true
 
       - name: Show conda installation info
-        run: conda info
+        run: |
+          conda info
+          conda list
 
       - name: Install build tools and dependencies into env
         run: |
-          conda install fortran-compiler cmake bmi-fortran
+          conda install -c conda-forge fortran-compiler cmake bmi-fortran
           conda list
 
       - name: Make cmake build directory

--- a/.github/workflows/conda-and-cmake.yml
+++ b/.github/workflows/conda-and-cmake.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install build tools and dependencies into env
         run: |
-          conda install -c conda-forge fortran-compiler cmake bmi-fortran
+          conda install -c conda-forge --override-channels fortran-compiler cmake bmi-fortran
           conda list
 
       - name: Make cmake build directory

--- a/.github/workflows/conda-and-cmake.yml
+++ b/.github/workflows/conda-and-cmake.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 
 jobs:
   build-linux-and-macos:
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
+
     runs-on: ${{ matrix.os }}
 
     defaults:

--- a/heat/heat.f90
+++ b/heat/heat.f90
@@ -54,10 +54,10 @@ contains
     type (heat_model), intent (inout) :: model
 
     model%id = 0
-    model%t = 0.
-    model%dt = 1.
     model%dx = 1.
     model%dy = 1.
+    model%t = 0.
+    model%dt = 1. / (4. * model%alpha)
 
     allocate(model%temperature(model%n_y, model%n_x))
     allocate(model%temperature_tmp(model%n_y, model%n_x))

--- a/heat/heat.f90
+++ b/heat/heat.f90
@@ -73,12 +73,18 @@ contains
   subroutine set_boundary_conditions(z)
     implicit none
     real, dimension (:,:), intent (out) :: z
-    integer :: i, top_x
+    integer :: i, nx, ny
 
-    top_x = size(z, 2)-1
+    nx = size(z, 2)
+    ny = size(z, 1)
 
-    do i = 0, top_x
-       z(1,i+1) = 0.25*top_x**2 - (i - 0.5*top_x)**2
+    do i = 1, nx-1
+       z(1,i) = 0.
+       z(ny-1,i) = 0.
+    end do
+    do i = 1, ny-1
+       z(i,1) = 0.
+       z(i,nx-1) = 0.
     end do
   end subroutine set_boundary_conditions
 

--- a/heat/heat.f90
+++ b/heat/heat.f90
@@ -62,8 +62,8 @@ contains
     allocate(model%temperature(model%n_y, model%n_x))
     allocate(model%temperature_tmp(model%n_y, model%n_x))
 
-    model%temperature = 0.
-    model%temperature_tmp = 0.
+    call random_number(model%temperature)
+    call random_number(model%temperature_tmp)
 
     call set_boundary_conditions(model%temperature)
     call set_boundary_conditions(model%temperature_tmp)

--- a/heat/heat.f90
+++ b/heat/heat.f90
@@ -78,13 +78,13 @@ contains
     nx = size(z, 2)
     ny = size(z, 1)
 
-    do i = 1, nx-1
+    do i = 1, nx
        z(1,i) = 0.
-       z(ny-1,i) = 0.
+       z(ny,i) = 0.
     end do
-    do i = 1, ny-1
+    do i = 1, ny
        z(i,1) = 0.
-       z(i,nx-1) = 0.
+       z(i,nx) = 0.
     end do
   end subroutine set_boundary_conditions
 

--- a/tests/fixtures.f90
+++ b/tests/fixtures.f90
@@ -3,6 +3,7 @@ module fixtures
   implicit none
 
   character (len=*), parameter :: config_file = ""
+  double precision, parameter :: tolerance  = 0.001d0
 
   integer :: status
 

--- a/tests/test_get_time_step.f90
+++ b/tests/test_get_time_step.f90
@@ -2,11 +2,11 @@ program test_get_time_step
 
   use bmif_2_0, only: BMI_FAILURE
   use bmiheatf
-  use fixtures, only: config_file, status
+  use fixtures, only: config_file, status, tolerance
 
   implicit none
 
-  double precision, parameter :: expected_time_step = 1.d0
+  double precision, parameter :: expected_time_step = 0.333333d0
 
   type (bmi_heat) :: m
   double precision :: time_step
@@ -15,7 +15,10 @@ program test_get_time_step
   status = m%get_time_step(time_step)
   status = m%finalize()
 
-  if (time_step.ne.expected_time_step) then
+  print *, time_step
+  print *, expected_time_step
+
+  if (abs(time_step - expected_time_step) > tolerance) then
      stop BMI_FAILURE
   end if
 end program test_get_time_step

--- a/tests/test_get_value.f90
+++ b/tests/test_get_value.f90
@@ -35,7 +35,7 @@ contains
     integer, parameter :: size = 50
     integer, parameter, dimension(rank) :: shape = (/ 10, 5 /)
     real, parameter, dimension(shape(2)) :: &
-         expected = (/ 0.0, 3.0, 4.0, 3.0, 0.0 /)
+         expected = (/ 0.0, 0.0, 0.0, 0.0, 0.0 /)
     real :: tval(size)
     integer :: i, code
 

--- a/tests/test_get_value_at_indices.f90
+++ b/tests/test_get_value_at_indices.f90
@@ -13,7 +13,7 @@ program test_get_value_at_indices
   integer, parameter, dimension(shape(2)) :: &
        indices = (/ 1, 11, 21, 31, 41 /)
   real, parameter, dimension(shape(2)) :: &
-       expected = (/ 0.0, 3.0, 4.0, 3.0, 0.0 /)
+       expected = (/ 0.0, 0.0, 0.0, 0.0, 0.0 /)
   integer :: retcode
 
   retcode = run_test()

--- a/tests/test_get_value_ptr.f90
+++ b/tests/test_get_value_ptr.f90
@@ -11,7 +11,7 @@ program test_get_value_ptr
   integer, parameter :: rank = 2
   integer, parameter, dimension(rank) :: shape = (/ 10, 5 /)
   real, parameter, dimension(shape(2)) :: &
-       expected = (/ 0.0, 3.0, 4.0, 3.0, 0.0 /)
+       expected = (/ 0.0, 0.0, 0.0, 0.0, 0.0 /)
   integer :: retcode
 
   retcode = run_test()

--- a/tests/test_update.f90
+++ b/tests/test_update.f90
@@ -2,11 +2,11 @@ program test_update
 
   use bmif_2_0, only: BMI_FAILURE
   use bmiheatf
-  use fixtures, only: config_file, status
+  use fixtures, only: config_file, status, tolerance
 
   implicit none
 
-  double precision, parameter :: expected_time = 1.d0
+  double precision, parameter :: expected_time = 0.333333d0
 
   type (bmi_heat) :: m
   double precision :: time
@@ -16,7 +16,10 @@ program test_update
   status = m%get_current_time(time)
   status = m%finalize()
 
-  if (time.ne.expected_time) then
+  print *, time
+  print *, expected_time
+
+  if (abs(time - expected_time) > tolerance) then
      stop BMI_FAILURE
   end if
 end program test_update

--- a/tests/test_update_until.f90
+++ b/tests/test_update_until.f90
@@ -2,7 +2,7 @@ program test_update_until
 
   use bmif_2_0, only: BMI_FAILURE, BMI_SUCCESS
   use bmiheatf
-  use fixtures, only: config_file, status
+  use fixtures, only: config_file, status, tolerance
 
   implicit none
 
@@ -41,13 +41,13 @@ contains
     print *, expected_time
 
     code = BMI_SUCCESS
-    if (time.ne.expected_time) then
+    if (abs(time - expected_time) > tolerance) then
        code = BMI_FAILURE
     end if
   end function test_more_than_dt
 
   function test_less_than_dt() result(code)
-    double precision, parameter :: expected_time = 0.5d0
+    double precision, parameter :: expected_time = 0.1d0
     double precision :: time
     integer :: code
 
@@ -61,17 +61,18 @@ contains
     print *, expected_time
 
     code = BMI_SUCCESS
-    if (time.ne.expected_time) then
+    if (abs(time - expected_time) > tolerance) then
        code = BMI_FAILURE
     end if
   end function test_less_than_dt
 
   function test_multiple_of_dt() result(code)
-    double precision, parameter :: expected_time = 3.0d0
-    double precision :: time
+    double precision :: time, dt, expected_time
     integer :: code
 
     status = m%initialize(config_file)
+    status = m%get_time_step(dt)
+    expected_time = 3 * dt
     status = m%update_until(expected_time)
     status = m%get_current_time(time)
     status = m%finalize()
@@ -81,7 +82,7 @@ contains
     print *, expected_time
 
     code = BMI_SUCCESS
-    if (time.ne.expected_time) then
+    if (abs(time - expected_time) > tolerance) then
        code = BMI_FAILURE
     end if
   end function test_multiple_of_dt


### PR DESCRIPTION
This PR is part of an attempt to standardize the diffusion model used in all four BMI examples. The model:

* uses a 2D uniform rectilinear grid
* has a random initial field
* has Dirichlet boundary conditions set to zero (temperature not conserved)
* uses a time step defined by a stability criterion: `dt = min(spacing)^2 / (4 * alpha)` 