### PR TITLE
Use pkgconfig to expose libraries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
           environment-name: testing
           create-args: >-
             cmake
+            pkg-config
             fortran-compiler
             bmi-fortran
 
@@ -79,6 +80,7 @@ jobs:
           environment-name: testing
           create-args: >-
             cmake
+            pkg-config
             cxx-compiler
           init-shell: >-
             powershell

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ jobs:
       run:
         shell: bash -l {0}
 
+    env:
+      SHLIB_EXT: ${{ matrix.os == 'ubuntu-latest' && '.so' || '.dylib' }}
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -46,7 +49,13 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         run: cmake --build . --target install --config ${{ matrix.build-type }}
 
-      - name: Test
+      - name: Test for installed files
+        run: |
+          test -h $CONDA_PREFIX/lib/libheatf${{ env.SHLIB_EXT }}
+          test -f $CONDA_PREFIX/include/heatf.mod
+          test -f $CONDA_PREFIX/lib/pkgconfig/heatf.pc
+
+      - name: Run CTest
         working-directory: ${{ github.workspace }}/build
         run: ctest -C ${{ matrix.build-type }} --output-on-failure
 
@@ -112,7 +121,7 @@ jobs:
           cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
-      - name: Test installed files
+      - name: Test for installed files
         run: |
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libheatf.a ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\run_heatf.exe ) ){ exit 1 }
@@ -123,6 +132,6 @@ jobs:
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmiheatf.mod ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\pkgconfig\bmiheatf.pc ) ){ exit 1 }
 
-      - name: Unit test with CTest
+      - name: Run CTest
         working-directory: ${{ github.workspace }}/build
         run: ctest -C Release -VV --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,9 @@ jobs:
 
     runs-on: windows-latest
 
+    env:
+      LIBRARY_PREFIX: $env:CONDA_PREFIX\Library
+
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
@@ -96,7 +99,7 @@ jobs:
             unzip bmi-fortran.zip
             cd bmi-fortran-master
             mkdir build && cd build
-            cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$env:CONDA_PREFIX" -DCMAKE_BUILD_TYPE=Release
+            cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
             cmake --build . --target install --config Release  
             cd ${{ github.workspace }}
 
@@ -106,17 +109,17 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$env:CONDA_PREFIX" -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Test installed files
         run: |
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\lib\libheatf.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\bin\run_heatf.exe ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\include\heatf.mod ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\bin\run_bmiheatf.exe ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\lib\libbmiheatf.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\include\bmiheatf.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libheatf.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\run_heatf.exe ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\heatf.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\run_bmiheatf.exe ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmiheatf.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmiheatf.mod ) ){ exit 1 }
 
       # - name: Unit test with CTest
       #   working-directory: ${{ github.workspace }}/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,12 @@ jobs:
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libheatf.a ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\run_heatf.exe ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\heatf.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\pkgconfig\heatf.pc ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\run_bmiheatf.exe ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmiheatf.a ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmiheatf.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\pkgconfig\bmiheatf.pc ) ){ exit 1 }
 
-      # - name: Unit test with CTest
-      #   working-directory: ${{ github.workspace }}/build
-      #   run: ctest -C Release -VV --output-on-failure
+      - name: Unit test with CTest
+        working-directory: ${{ github.workspace }}/build
+        run: ctest -C Release -VV --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
           test -h $CONDA_PREFIX/lib/libheatf${{ env.SHLIB_EXT }}
           test -f $CONDA_PREFIX/include/heatf.mod
           test -f $CONDA_PREFIX/lib/pkgconfig/heatf.pc
+          test -h $CONDA_PREFIX/lib/libbmiheatf${{ env.SHLIB_EXT }}
+          test -f $CONDA_PREFIX/include/bmiheatf.mod
+          test -f $CONDA_PREFIX/lib/pkgconfig/bmiheatf.pc
 
       - name: Run CTest
         working-directory: ${{ github.workspace }}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,25 +12,15 @@ include(GNUInstallDirs)
 set(model_name heatf)
 set(bmi_name bmi${model_name})
 
-# Determine the Fortran BMI version.
-if(DEFINED ENV{BMIF_VERSION})
-  set(bmif_version $ENV{BMIF_VERSION})
-else()
-  set(bmif_version "2.0")
-endif()
-string(REPLACE "." "_" bmif_module_version ${bmif_version})
-message("-- BMIF version - ${bmif_version}")
-message("-- BMIF module version - ${bmif_module_version}")
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(BMIF REQUIRED IMPORTED_TARGET bmif)
+string(REPLACE "." "_" bmif_module_version ${BMIF_VERSION})
+message("--   bmif module version - ${bmif_module_version}")
+message("--   bmif library path - ${BMIF_LINK_LIBRARIES}")
+message("--   bmif include dir - ${BMIF_INCLUDE_DIRS}")
+include_directories(${BMIF_INCLUDE_DIRS})
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
-
-# Locate the installed Fortran BMI bindings (bmif library and module file)
-# through CMAKE_PREFIX_PATH.
-find_library(bmif_lib bmif)
-find_path(bmif_inc bmif_${bmif_module_version}.mod)
-include_directories(${bmif_inc})
-message("-- bmif_lib - ${bmif_lib}")
-message("-- bmif_inc - ${bmif_inc}")
 
 add_subdirectory(heat)
 add_subdirectory(bmi_heat)

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ This example can be built on Linux, macOS, and Windows.
   in that repository.  You can choose to build them from source or
   install them through a conda binary. If using fpm, the binding
   will be automatically downloaded and built for you.
+* pkg-config
 
 ### CMake - Linux and macOS
 
 To build this example from source with CMake,
 using the current Fortran BMI version, run
 
-    export BMIF_VERSION=2.0
     mkdir _build && cd _build
     cmake .. -DCMAKE_INSTALL_PREFIX=<path-to-installation>
     make
@@ -80,12 +80,15 @@ The installation will look like
 |   |-- bmiheatf.mod
 |   `-- heatf.mod
 `-- lib
-    |-- libbmif.2.0.dylib
-    |-- libbmif.dylib -> libbmif.2.0.dylib
+    |-- libbmif.a
+    |-- libbmif.2.0.2.dylib
+    |-- libbmif.dylib -> libbmif.2.0.2.dylib
     |-- libbmiheatf.dylib
-    `-- libheatf.dylib
-
-3 directories, 9 files
+    |-- libheatf.dylib
+    `-- pkgconfig
+        |-- bmif.pc
+        |-- bmiheatf.pc
+        `-- heatf.pc
 ```
 
 From the build directory,
@@ -103,7 +106,6 @@ To configure this example from source with cmake
 using the current Fortran BMI version,
 run the following in a [Developer Command Prompt](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs)
 
-    set "BMIF_VERSION=2.0"
     mkdir _build && cd _build
     cmake .. ^
 	  -G "NMake Makefiles" ^

--- a/bmi_heat/CMakeLists.txt
+++ b/bmi_heat/CMakeLists.txt
@@ -6,7 +6,7 @@ if(WIN32)
 else()
   add_library(${bmi_name} SHARED bmi_heat.f90)
 endif()
-target_link_libraries(${bmi_name} ${model_name} ${bmif_lib})
+target_link_libraries(${bmi_name} ${model_name} ${BMIF_LINK_LIBRARIES})
 
 add_executable(run_${bmi_name} bmi_main.f90)
 target_link_libraries(run_${bmi_name} ${bmi_name})

--- a/bmi_heat/CMakeLists.txt
+++ b/bmi_heat/CMakeLists.txt
@@ -1,5 +1,11 @@
 # bmi-heat
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/${bmi_name}.pc.cmake
+  ${CMAKE_BINARY_DIR}/bmi_heat/${bmi_name}.pc
+  @ONLY
+)
+
 # Create shared library, except on Windows.
 if(WIN32)
   add_library(${bmi_name} bmi_heat.f90)
@@ -24,4 +30,8 @@ install(
 install(
   FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmi_name}.mod
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/${bmi_name}.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/bmi_heat/CMakeLists.txt
+++ b/bmi_heat/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/${bmi_name}.pc.cmake
-  ${CMAKE_BINARY_DIR}/bmi_heat/${bmi_name}.pc
+  ${CMAKE_CURRENT_BINARY_DIR}/${bmi_name}.pc
   @ONLY
 )
 

--- a/bmi_heat/bmiheatf.pc.cmake
+++ b/bmi_heat/bmiheatf.pc.cmake
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: @bmi_name@
 Description: BMI for the heatf model
 Version: @CMAKE_PROJECT_VERSION@
-Requires: @model_name@
+Requires: @model_name@, @BMIF_LIBRARIES@
 Libs: -L${libdir} -l@bmi_name@
 Cflags: -I${includedir}

--- a/bmi_heat/bmiheatf.pc.cmake
+++ b/bmi_heat/bmiheatf.pc.cmake
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: @bmi_name@
+Description: BMI for the heatf model
+Version: @CMAKE_PROJECT_VERSION@
+Requires: @model_name@
+Libs: -L${libdir} -l@bmi_name@
+Cflags: -I${includedir}

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -1,5 +1,11 @@
 # heat
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/${model_name}.pc.cmake
+  ${CMAKE_BINARY_DIR}/heat/${model_name}.pc
+  @ONLY
+)
+
 # Create shared library, except on Windows.
 if(WIN32)
   add_library(${model_name} heat.f90)
@@ -23,4 +29,8 @@ install(
 install(
   FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${model_name}.mod
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/${model_name}.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/${model_name}.pc.cmake
-  ${CMAKE_BINARY_DIR}/heat/${model_name}.pc
+  ${CMAKE_CURRENT_BINARY_DIR}/${model_name}.pc
   @ONLY
 )
 

--- a/heat/heatf.pc.cmake
+++ b/heat/heatf.pc.cmake
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: @model_name@
+Description: The two-dimensional heat equation in Fortran
+Version: @CMAKE_PROJECT_VERSION@
+Libs: -L${libdir} -l@model_name@
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR adds pkg-config files to help other applications find the *heatf* and *bmiheatf* libraries. The build process has also been updated to consume the pkg-config file from the dependent *bmif* library (see https://github.com/csdms/bmi-fortran/pull/53).